### PR TITLE
パスプレフィックスオプションの追加

### DIFF
--- a/src/duckdb_hybrid_document_search/server.py
+++ b/src/duckdb_hybrid_document_search/server.py
@@ -16,6 +16,7 @@ def run_server(
     db_path: str,
     prefix: str,
     rerank_model: str,
+    path_prefix_to_remove: Optional[str] = None,
     tool_name: str = "search_documents",
     tool_description: str = "Search for local documents",
     transport: Literal["stdio", "streamable-http"] = "stdio",
@@ -29,6 +30,7 @@ def run_server(
         db_path: Path to DuckDB database
         prefix: Prefix to add to file paths in search results
         rerank_model: Hugging Face model ID for reranking
+        path_prefix_to_remove: Prefix to remove from file paths in search results
         tool_name: Name of the MCP tool (default: "search_documents")
         tool_description: Description of the MCP tool (default: "Search for local documents")
         transport: Transport protocol to use (default: "stdio")
@@ -86,6 +88,7 @@ def run_server(
             query=query,
             top_k=top_k,
             file_path_prefix=prefix,
+            path_prefix_to_remove=path_prefix_to_remove,
             rerank=True,
         )
 


### PR DESCRIPTION
## 概要

検索結果のパス処理に関する新しいオプションを追加しました：

1. `--path-prefix-to-remove` (`-r`): 検索結果のパスからプレフィックスを削除するオプション
2. `--path-prefix-to-add` (`-p`): 検索結果のパスにプレフィックスを追加するオプション（既存の`--file-path-prefix`をリネーム）

## 処理順序

パスの処理順序は以下の通りです：
1. プレフィックスの削除
2. プレフィックスの追加

## 変更内容

- `searcher.py`の`search`関数に`path_prefix_to_remove`パラメータを追加
- `cli.py`の`search`コマンドと`serve`コマンドに新しいオプションを追加
- `server.py`の`run_server`関数と`search_documents`関数も同様に更新

## 使用例

```bash
# 検索コマンドでの使用例
duckdb-hybrid-doc-search search --query "検索クエリ" --path-prefix-to-remove "/original/path" --path-prefix-to-add "/new/path"

# サーバーコマンドでの使用例
duckdb-hybrid-doc-search serve --path-prefix-to-remove "/original/path" --path-prefix-to-add "/new/path"
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 検索結果のファイルパスに対して、指定したプレフィックスの除去と追加が可能になりました。
  - コマンドラインオプションに、パスの除去用（--path-prefix-to-remove/-r）と追加用（--path-prefix-to-add/-p）の2つのフラグが追加されました。

- **改善**
  - パス操作に関するCLIオプション名や短縮フラグが見直され、より直感的に利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->